### PR TITLE
Header bar to show kernel activity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ipynb_checkpoints
 *.egg-info
+dist

--- a/share/jupyter/voila/templates/debug/nbconvert_templates/debug.tpl
+++ b/share/jupyter/voila/templates/debug/nbconvert_templates/debug.tpl
@@ -1,8 +1,32 @@
 {%- extends 'voila.tpl' -%}
 
-{%- block body -%}
+{%- block html_head_css -%}
+{{ super() }}
+<link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/toolbar.css"></link>
+<link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/override.css"></link>
+{%- endblock html_head_css -%}
 
-<div class="jp-RenderedHTMLCommon">Kernel Status: <span id="kernel-status"></span></div>
+{%- block body -%}
+{% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
+{% set kernel_display_name = nb.metadata.get('kernelspec', {}).get('display_name', '') %}
+
+<div>
+    <div class="p-Widget jp-Toolbar" style="min-height: var(--jp-private-toolbar-height); height: 36px;">
+        <div class="p-Widget jp-Toolbar-item">
+            {{ nb_title}}
+        </div>
+        <div class="p-Widget jp-Toolbar-spacer jp-Toolbar-item">
+        </div>
+        <button id="kernel-indicator" class="jp-Dialog-button jp-mod-accept jp-mod-styled">
+            <div id="kernel-indicator-label" class="jp-Dialog-buttonLabel" title=""></div>
+        </button>
+        <div class="p-Widget jp-KernelName jp-Toolbar-item">
+            {{ kernel_display_name }}
+        </div>
+        <div id="kernel-activity" class="jp-Toolbar-kernelStatus jp-Toolbar-item jp-CircleIcon" title="Kernel Idle">
+        </div>
+    </div>
+</div>
 
 {{ super() }}
 {%- endblock body -%}

--- a/share/jupyter/voila/templates/debug/nbconvert_templates/util.js
+++ b/share/jupyter/voila/templates/debug/nbconvert_templates/util.js
@@ -1,6 +1,25 @@
 window.debug_init = async (voila) => {
   const kernel = await voila.connectKernel();
   kernel.statusChanged.connect((sender, status) => {
-      $("#kernel-status").text(status)
+    switch (status) {
+      case "idle":
+        $("#kernel-activity").removeClass("jp-FilledCircleIcon").addClass("jp-CircleIcon");
+        $("#kernel-indicator").fadeOut(500);
+        break;
+      case "busy":
+        $("#kernel-activity").removeClass("jp-CircleIcon").addClass("jp-FilledCircleIcon");
+        $("#kernel-indicator").fadeOut(500);
+        break;
+      case "restarting":
+        $("#kernel-indicator").addClass("jp-mod-warn");
+        $("#kernel-indicator-label").text("Restarting");
+        $("#kernel-indicator").show();
+        break;
+      case "connected":
+        $("#kernel-indicator").removeClass("jp-mod-warn");
+        $("#kernel-indicator-label").text("Connected");
+        $("#kernel-indicator").show();
+        break;
+    }
   });
 };

--- a/share/jupyter/voila/templates/debug/static/override.css
+++ b/share/jupyter/voila/templates/debug/static/override.css
@@ -1,0 +1,3 @@
+.jp-Toolbar .jp-Dialog-button {
+    margin-right: 10px;
+}

--- a/share/jupyter/voila/templates/debug/static/toolbar.css
+++ b/share/jupyter/voila/templates/debug/static/toolbar.css
@@ -1,0 +1,104 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*
+Copied from: https://github.com/jupyterlab/jupyterlab/blob/master/packages/apputils/style/toolbar.css
+*/
+
+:root {
+  --jp-private-toolbar-height: calc(
+    28px + var(--jp-border-width)
+  ); /* leave 28px for content */
+}
+
+.jp-Toolbar {
+  color: var(--jp-ui-font-color1);
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: row;
+  border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  background: var(--jp-toolbar-background);
+  min-height: var(--jp-toolbar-micro-height);
+  padding: 2px;
+  z-index: 1;
+}
+
+/* Toolbar items */
+
+.jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-spacer {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.jp-Toolbar-item.jp-Toolbar-kernelStatus {
+  display: inline-block;
+  width: 32px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px;
+}
+
+.jp-Toolbar > .jp-Toolbar-item {
+  flex: 0 0 auto;
+  display: flex;
+  padding-left: 1px;
+  padding-right: 1px;
+  font-size: var(--jp-ui-font-size1);
+  line-height: var(--jp-private-toolbar-height);
+  height: 100%;
+}
+
+/* Toolbar buttons */
+
+/* This is the div we use to wrap the react component into a Widget */
+div.jp-ToolbarButton {
+  color: transparent;
+  border: none;
+  box-sizing: border-box;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 0px;
+  margin: 0px;
+}
+
+button.jp-ToolbarButtonComponent {
+  background: var(--jp-layout-color1);
+  border: none;
+  box-sizing: border-box;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 0px 6px;
+  margin: 0px;
+  height: 24px;
+  border-radius: var(--jp-border-radius);
+  display: flex;
+  align-items: center;
+  text-align: center;
+  font-size: 14px;
+  min-width: unset;
+  min-height: unset;
+}
+
+button.jp-ToolbarButtonComponent:disabled {
+  opacity: 0.4;
+}
+
+button.jp-ToolbarButtonComponent span {
+  padding: 0px;
+  flex: 0 0 auto;
+}
+
+button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
+  font-size: var(--jp-ui-font-size1);
+  line-height: 100%;
+  padding-left: 2px;
+  color: var(--jp-ui-font-color1);
+}


### PR DESCRIPTION
Add a header bar to show kernel activity:
- reuse JupyterLab's toolbar look and css
- show kernel activity icon
- show kernel display name
- show "Restarting" and "Connected" indicators

![voila-debug-kernels](https://user-images.githubusercontent.com/591645/61577555-3da77f80-aae9-11e9-96dd-810fc08a9d7b.gif)

This change bundles `toolbar.css` from JupyterLab as the themes shipped with voila do not include it.

A follow-up for this could be to add a proper build step that would be triggered on `pip install`, and would produce a self contained bundle in the template folder (similar to the [JupyterLab examples](https://github.com/jupyterlab/jupyterlab/tree/master/examples))